### PR TITLE
get up to 100 runners in per request

### DIFF
--- a/src/gh.js
+++ b/src/gh.js
@@ -9,7 +9,10 @@ async function getRunners(label) {
   const octokit = github.getOctokit(config.input.githubToken);
 
   try {
-    const runners = await octokit.paginate('GET /repos/{owner}/{repo}/actions/runners', config.githubContext);
+    const runners = await octokit.paginate('GET /repos/{owner}/{repo}/actions/runners', {
+      ...config.githubContext,
+      per_page: 100,
+    });
     const foundRunners = _.filter(runners, { labels: [{ name: label }] });
     return foundRunners.length > 0 ? foundRunners : null;
   } catch (error) {


### PR DESCRIPTION
to get all the runners we are looping over all the pages . increase the page size to consume less requests. 

ref https://github.com/octokit/octokit.js?tab=readme-ov-file#pagination