### PR TITLE
 Avoid failures when other runners are already registered with same name #127 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Check the [internal docs](https://docs.shiphero.xyz/ci.html#horizontally-scaled-
 
   This allows to save around 45' on the "start" step. </strike>
 
-  Reverted in 5659035ee505 because we was hitting Github rate limits for personal tokens.
+  Reverted in [5659035ee505](https://github.com/Shiphero/ec2-github-runner/commit/5659035ee5055b3c32cd4d104ccfa339472250b0) because we were hitting Github's rate limit for personal tokens.
 
 - [Increases the page size when listing runners](https://github.com/Shiphero/ec2-github-runner/pull/2/commits/e3aae63b6a8bd136b0fd9460468dc85097a8d273) to reduce the number or requests to Github API. 
 
+- [Avoid failures when other runners are already registered with same name](https://github.com/Shiphero/ec2-github-runner/pull/4) by assigning a random name to the instances. 

--- a/src/aws.js
+++ b/src/aws.js
@@ -13,7 +13,7 @@ function buildUserDataScript(githubRegistrationToken, label) {
       `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
       'source pre-runner-script.sh',
       'export RUNNER_ALLOW_RUNASROOT=1',
-      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
+      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label} --name $(hostname)-$(uuidgen)`,
       './run.sh',
     ];
   } else {
@@ -26,7 +26,7 @@ function buildUserDataScript(githubRegistrationToken, label) {
       'curl -O -L https://github.com/actions/runner/releases/download/v2.313.0/actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.313.0.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
-      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
+      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label} --name $(hostname)-$(uuidgen)`,
       './run.sh',
     ];
   }


### PR DESCRIPTION
### Issue
```
[  355.184408] cloud-init[1213]: A runner exists with the same name
[  355.184574] cloud-init[1213]: Would you like to replace the existing runner? (Y/N) [press Enter for N] Enter the name of runner: [press Enter for ip-10-20-24-96]
[  355.184669] cloud-init[1213]: This runner will have the following labels: 'self-hosted', 'Linux', 'X64'
[  355.184816] cloud-init[1213]: Enter any additional labels (ex. label-1,label-2): [press Enter to skip]
```

### Solution
Merging https://github.com/machulav/ec2-github-runner/pull/127
![Screenshot from 2024-08-08 17-57-52](https://github.com/user-attachments/assets/84ef57e4-bf9d-4179-892f-0a90c983a7b4)
