### PR TITLE
fix(aws) Get the github runner latest version from HTML instead of api

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -65282,12 +65282,14 @@ function buildUserDataScript(githubRegistrationToken, label) {
   } else {
     return [
       '#!/bin/bash',
+      'set -euo pipefail',
       'mkdir actions-runner && cd actions-runner',
       `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
       'source pre-runner-script.sh',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
-        "VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep tag_name | grep -oP '\\d+(\\.\\d+)*')",
-      'curl -O -L https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
+      "VERSION=$(curl --fail -L https://github.com/actions/runner/releases/latest | grep '/actions/runner/tree' | grep -oP 'v[.\\d]+' | tr -d v | head -1)",
+      'echo curl --fail -O -L https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
+      'curl --fail -O -L https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label} --name $(hostname)-$(uuidgen)`,

--- a/src/aws.js
+++ b/src/aws.js
@@ -19,12 +19,14 @@ function buildUserDataScript(githubRegistrationToken, label) {
   } else {
     return [
       '#!/bin/bash',
+      'set -euo pipefail',
       'mkdir actions-runner && cd actions-runner',
       `echo "${config.input.preRunnerScript}" > pre-runner-script.sh`,
       'source pre-runner-script.sh',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
-        "VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | grep tag_name | grep -oP '\\d+(\\.\\d+)*')",
-      'curl -O -L https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
+      "VERSION=$(curl --fail -L https://github.com/actions/runner/releases/latest | grep '/actions/runner/tree' | grep -oP 'v[.\\d]+' | tr -d v | head -1)",
+      'echo curl --fail -O -L https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
+      'curl --fail -O -L https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-${VERSION}.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label} --name $(hostname)-$(uuidgen)`,


### PR DESCRIPTION
### Issue
We are hitting rate limits when we query the latest runner version

### Solution
Scrap the version from the HTML releases page

```sh
curl --fail -L https://github.com/actions/runner/releases/latest | grep '/actions/runner/tree' | grep -oP 'v[.\d]+' | tr -d v | head -1
```

